### PR TITLE
Fix updateAll rectify for id inq where filter

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1623,18 +1623,18 @@ module.exports = function(registry) {
 
   function rectifyOnSave(ctx, next) {
     var instance = ctx.instance || ctx.currentInstance;
-    var id = instance ? instance.getId() :
-      getIdFromWhereByModelId(ctx.Model, ctx.where);
+    var ids = instance ? [instance.getId()] :
+      getIdsFromWhereByModelId(ctx.Model, ctx.where);
 
     if (debug.enabled) {
-      debug('rectifyOnSave %s -> ' + (id ? 'id %j' : '%s'),
-        ctx.Model.modelName, id ? id : 'ALL');
+      debug('rectifyOnSave %s -> ' + (ids ? 'ids %j' : '%s'),
+        ctx.Model.modelName, ids ? ids : 'ALL');
       debug('context instance:%j currentInstance:%j where:%j data %j',
         ctx.instance, ctx.currentInstance, ctx.where, ctx.data);
     }
 
-    if (id) {
-      ctx.Model.rectifyChange(id, reportErrorAndNext);
+    if (ids) {
+      ctx.Model.rectifyChanges(ids, reportErrorAndNext);
     } else {
       ctx.Model.rectifyAllChanges(reportErrorAndNext);
     }
@@ -1648,17 +1648,17 @@ module.exports = function(registry) {
   }
 
   function rectifyOnDelete(ctx, next) {
-    var id = ctx.instance ? ctx.instance.getId() :
-      getIdFromWhereByModelId(ctx.Model, ctx.where);
+    var ids = ctx.instance ? [ctx.instance.getId()] :
+      getIdsFromWhereByModelId(ctx.Model, ctx.where);
 
     if (debug.enabled) {
-      debug('rectifyOnDelete %s -> ' + (id ? 'id %j' : '%s'),
-        ctx.Model.modelName, id ? id : 'ALL');
+      debug('rectifyOnDelete %s -> ' + (ids ? 'ids %j' : '%s'),
+        ctx.Model.modelName, ids ? ids : 'ALL');
       debug('context instance:%j where:%j', ctx.instance, ctx.where);
     }
 
-    if (id) {
-      ctx.Model.rectifyChange(id, reportErrorAndNext);
+    if (ids) {
+      ctx.Model.rectifyChanges(ids, reportErrorAndNext);
     } else {
       ctx.Model.rectifyAllChanges(reportErrorAndNext);
     }
@@ -1671,14 +1671,18 @@ module.exports = function(registry) {
     }
   }
 
-  function getIdFromWhereByModelId(Model, where) {
+  function getIdsFromWhereByModelId(Model, where) {
     var idName = Model.getIdName();
     if (!(idName in where)) return undefined;
 
     var id = where[idName];
     // TODO(bajtos) support object values that are not LB conditions
     if (typeof id === 'string' || typeof id === 'number') {
-      return id;
+      return [id];
+    } else if (typeof id === 'object') {
+      if (id.inq && Array.isArray(id.inq)) {
+        return id.inq;
+      }
     }
     return undefined;
   }
@@ -1741,6 +1745,19 @@ module.exports = function(registry) {
   PersistedModel.rectifyChange = function(id, callback) {
     var Change = this.getChangeModel();
     Change.rectifyModelChanges(this.modelName, [id], callback);
+  };
+
+  /**
+   * Specify that changes to the models with the given IDs have occurred.
+   *
+   * @param {Array} ids The IDs of the models that have changed.
+   * @callback {Function} callback
+   * @param {Error} err
+   */
+
+  PersistedModel.rectifyChanges = function(ids, callback) {
+    var Change = this.getChangeModel();
+    Change.rectifyModelChanges(this.modelName, ids, callback);
   };
 
   PersistedModel.findLastChange = function(id, cb) {


### PR DESCRIPTION
PersistedModel#updateAll does not scale when called with multiple ids
in the where filter as rectifyAllChanges is called. This change adds
Model#rectifyChanges (called with an array of ids) and support for the
inq operator in the id of the where filter.