### PR TITLE
Update the arg type for `updates` in `bulkUpdate`

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -954,7 +954,7 @@ module.exports = function(registry) {
         description: 'Run multiple updates at once. Note: this is not atomic.',
         accessType: 'WRITE',
         accepts: [
-          {arg: 'updates', type: 'array'},
+          {arg: 'updates', type: ['object'] },
           {arg: 'options', type: 'object', http: 'optionsFromRequest'},
         ],
         http: {verb: 'post', path: '/bulk-update'}


### PR DESCRIPTION
This prevents strong-remoting from coercing all properties on the JSON data
