### PR TITLE
Simple delete

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1585,7 +1585,7 @@ module.exports = function(registry) {
       return Change.rectifyModelChanges(Model.modelName, [id], cb);
     }
 
-    Model.deleteAll(current.toObject(), options, function(err, result) {
+    Model.deleteById(id, options, function(err, result) {
       if (err) return cb(err);
 
       var count = result && result.count;


### PR DESCRIPTION
fix delete to be simple as sqllite doesn't handle embedded objects
### Type of change

- [ ] SEMVER-MAJOR -- Backwards-incompatible changes
- [ ] SEMVER-MINOR -- Add functionality in a backwards-compatible manner
- [x ] SEMVER-PATCH -- Backwards-compatible bug fixes

### Description of change(s)



### Link(s) to related GitHub issues



### Checklist

- [ ] CLA signed
- [ ] Commit message conforms with the [Git commit message
  guidelines](http://loopback.io/doc/en/contrib/git-commit-messages.html)
- [ ] New tests are added to cover all changes
- [ ] Code passes `npm test`
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] All CI builds are passing (semi-required, left up to discretion of the
  reviewer)
