### PR TITLE
Enable PersistedModel children to sort updates during replicate

### DIFF
--- a/lib/persisted-model.js
+++ b/lib/persisted-model.js
@@ -1216,6 +1216,17 @@ module.exports = function(registry) {
     }
   };
 
+  /**
+   * Intended to be implemented by child classes if there is a specific requirement
+   * for replication updates (sent via bulkUpdate) to be in a particular order
+   * before they are chunked for sending
+   *
+   * @param {Update[]} updates Array of updates to be sorted before sending to bulkUpdate
+   */
+  PersistedModel.sortReplicateUpdates = function(updates) {
+    return updates;
+  }
+
   PersistedModel.getChunkSize = function() {
     var chunkSize = undefined;
 
@@ -1244,6 +1255,7 @@ module.exports = function(registry) {
       getSourceChanges,
       getDiffFromTarget,
       createSourceUpdates,
+      sortUpdates,
       bulkUpdate
     ];
 
@@ -1292,6 +1304,15 @@ module.exports = function(registry) {
       } else {
         // nothing to replicate
         done();
+      }
+    }
+
+    function sortUpdates(_updates, cb) {
+      debug('\tstarting sort updates');
+      if (sourceModel.sortReplicateUpdates) {
+        cb(null, sourceModel.sortReplicateUpdates(_updates));
+      } else {
+        cb(null, _updates);
       }
     }
 


### PR DESCRIPTION
<!--
See http://loopback.io/doc/en/contrib/triaging-pull-requests.html to understand
the MINIMUM requirements for submitting pull requests.
-->

### Type of change

<!--
See http://semver.org/ for more info.
-->

- [ ] SEMVER-MAJOR -- Backwards-incompatible changes
- [x] SEMVER-MINOR -- Add functionality in a backwards-compatible manner
- [ ] SEMVER-PATCH -- Backwards-compatible bug fixes

### Description of change(s)
Allow for optional sorting of updates to be replicated before they are chunked and sent to `bulkUpdate`.

- Add a `sortReplicateUpdates` method to `PersistedModel`
- Add a `sortUpdates` task to `PersistedModel.replicate`


### Link(s) to related GitHub issues



### Checklist

- [ ] CLA signed
- [ ] Commit message conforms with the [Git commit message
  guidelines](http://loopback.io/doc/en/contrib/git-commit-messages.html)
- [ ] New tests are added to cover all changes
- [ ] Code passes `npm test`
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] All CI builds are passing (semi-required, left up to discretion of the
  reviewer)
